### PR TITLE
most likely a typo fix

### DIFF
--- a/foundations/02-class-id-selectors/README.md
+++ b/foundations/02-class-id-selectors/README.md
@@ -19,4 +19,4 @@ Quick tip: in VS Code, you can change which format colors are displayed in (RGB,
 ### Self Check
 - Do the odd numbered `p` elements share a class?
 - Do the even numbered `div` elements have unique ID's?
-- Does the 3rd `div` element have multiple classes?
+- Does the 3rd `p` element have multiple classes?


### PR DESCRIPTION
On the self check line it says

- Does the 3rd `div` element have multiple classes?

and the only element that has more than one class is a `p` element